### PR TITLE
Fix wrong access to timezone value in browsermob chart

### DIFF
--- a/charts/browsermob/templates/browsermob-deployment.yaml
+++ b/charts/browsermob/templates/browsermob-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           env:
             - name: JAVA_TOOL_OPTIONS
               value: {{ default "" .Values.browsermob.javaOpts | quote }}
-            {{- if .Values.hub.timeZone }}
+            {{- if .Values.browsermob.timeZone }}
             - name: TZ
               value: {{ .Values.browsermob.timeZone | quote }}
             {{- end }}


### PR DESCRIPTION
There was a small bug when the deployment template tried to access the timezone value. This issue is fixed now.